### PR TITLE
Run for a minimum duration if no number of iterations is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+* Add min_duration argument
+
 ### Changed
 * Disable REPL printing during profiling
 

--- a/tests/test_timerit.py
+++ b/tests/test_timerit.py
@@ -111,6 +111,36 @@ def test_hacked_timerit_verbose():
             time per loop: best=42.000 s, mean=42.000 +- 0.0 s
         ''').strip()
 
+    with CaptureStdout(suppress=False) as cap:
+        HackedTimerit(label='foo', verbose=0, min_duration=100).call(lambda: None)
+    assert cap.text.strip() == textwrap.dedent(
+        '''
+        ''').strip()
+
+    with CaptureStdout(suppress=False) as cap:
+        HackedTimerit(label='foo', verbose=1, min_duration=100).call(lambda: None)
+    assert cap.text.strip() == textwrap.dedent(
+        '''
+        Timed best=42.000 s, mean=42.000 +- 0.0 s for foo
+        ''').strip()
+
+    with CaptureStdout(suppress=False) as cap:
+        HackedTimerit(label='foo', verbose=2, min_duration=100).call(lambda: None)
+    assert cap.text.strip() == textwrap.dedent(
+        '''
+        Timed foo for: 3 loops, best of 3
+            time per loop: best=42.000 s, mean=42.000 +- 0.0 s
+        ''').strip()
+
+    with CaptureStdout(suppress=False) as cap:
+        HackedTimerit(label='foo', verbose=3, min_duration=100).call(lambda: None)
+    assert cap.text.strip() == textwrap.dedent(
+        '''
+        Timing foo for: 100.000s
+        Timed foo for: 3 loops, best of 3
+            body took: 126.000 s
+            time per loop: best=42.000 s, mean=42.000 +- 0.0 s
+        ''').strip()
 
 def test_timer_default_verbosity():
 

--- a/tests/test_timerit.py
+++ b/tests/test_timerit.py
@@ -112,20 +112,20 @@ def test_hacked_timerit_verbose():
         ''').strip()
 
     with CaptureStdout(suppress=False) as cap:
-        HackedTimerit(label='foo', verbose=0, min_duration=100).call(lambda: None)
+        HackedTimerit(num=None, label='foo', verbose=0, min_duration=100).call(lambda: None)
     assert cap.text.strip() == textwrap.dedent(
         '''
         ''').strip()
 
     with CaptureStdout(suppress=False) as cap:
-        HackedTimerit(label='foo', verbose=1, min_duration=100).call(lambda: None)
+        HackedTimerit(num=None, label='foo', verbose=1, min_duration=100).call(lambda: None)
     assert cap.text.strip() == textwrap.dedent(
         '''
         Timed best=42.000 s, mean=42.000 +- 0.0 s for foo
         ''').strip()
 
     with CaptureStdout(suppress=False) as cap:
-        HackedTimerit(label='foo', verbose=2, min_duration=100).call(lambda: None)
+        HackedTimerit(num=None, label='foo', verbose=2, min_duration=100).call(lambda: None)
     assert cap.text.strip() == textwrap.dedent(
         '''
         Timed foo for: 3 loops, best of 3
@@ -133,7 +133,7 @@ def test_hacked_timerit_verbose():
         ''').strip()
 
     with CaptureStdout(suppress=False) as cap:
-        HackedTimerit(label='foo', verbose=3, min_duration=100).call(lambda: None)
+        HackedTimerit(num=None, label='foo', verbose=3, min_duration=100).call(lambda: None)
     assert cap.text.strip() == textwrap.dedent(
         '''
         Timing foo for: 100.000s
@@ -141,6 +141,7 @@ def test_hacked_timerit_verbose():
             body took: 126.000 s
             time per loop: best=42.000 s, mean=42.000 +- 0.0 s
         ''').strip()
+
 
 def test_timer_default_verbosity():
 

--- a/timerit/core.py
+++ b/timerit/core.py
@@ -278,7 +278,7 @@ class Timerit:
     _default_precision = 3
     _default_precision_type = 'f'  # could also be reasonably be 'g' or ''
 
-    def __init__(self, num=None, label=None, bestof=3, unit=None, verbose=None,
+    def __init__(self, num=1, label=None, bestof=3, unit=None, verbose=None,
                  disable_gc=True, timer_cls=None, min_duration=0.2):
         """
         Args:
@@ -318,9 +318,10 @@ class Timerit:
 
             min_duration (float):
                 Continue running the loop until the given amount of time has
-                elapsed.  This allows running the loop enough times to get a
-                robust measurement without having to know a priori how long
-                each iteration of the loop will take.
+                elapsed.  This makes it easier to run the loop enough times to
+                get a robust measurement without having to know a priori how
+                long each iteration of the loop will take.  Note that this
+                argument is ignored if the *num* argument is not None.
         """
         if verbose is None:
             verbose = bool(label)
@@ -711,10 +712,10 @@ class Timerit:
             >>> from time import sleep
             >>> t = Timerit()
             >>> print(t._status_line())
-            Timing for: 0.200s
+            Timing for: 1 loops, best of 1
             >>> t.call(sleep, 0.01)
             >>> print(t._status_line())
-            Timed for: 20 loops, best of 3
+            Timed for: 1 loops, best of 1
         """
 
         tense = 'present' if self.n_loops is None else 'past'

--- a/timerit/core.py
+++ b/timerit/core.py
@@ -282,11 +282,9 @@ class Timerit:
                  disable_gc=True, timer_cls=None, min_duration=0.2):
         """
         Args:
-            num (int):
-                Number of times to run the loop.  By default, the loop will keep
-                running until the amount of time specified by the *min_duration*
-                argument has elapsed.  This argument eliminates this behavior
-                and simply runs the loop the specified number of times.
+            num (int | None):
+                Number of times to run the loop.  If None, then the number of
+                loops is determined by ``min_duration``.
 
             label (str | None):
                 An identifier for printing and differentiating between
@@ -317,11 +315,8 @@ class Timerit:
                 customized one. Mainly useful for testing.
 
             min_duration (float):
-                Continue running the loop until the given amount of time has
-                elapsed.  This makes it easier to run the loop enough times to
-                get a robust measurement without having to know a priori how
-                long each iteration of the loop will take.  Note that this
-                argument is ignored if the *num* argument is not None.
+                Run the loop until the given amount of time has elapsed.
+                Ignored unless ``num is None``.
         """
         if verbose is None:
             verbose = bool(label)
@@ -447,7 +442,7 @@ class Timerit:
                     if self.n_loops >= self.num:
                         break
 
-                # Start background timer (in case the user doesn't use 
+                # Start background timer (in case the user doesn't use
                 # fg_timer)
                 # Yield foreground timer to let the user run a block of code
                 # When we return from yield the user code will have just finished
@@ -893,12 +888,13 @@ class _SetGCState(object):
         else:
             gc.disable()
 
+
 class _SetDisplayHook(object):
     """
-    Context manager to prevent the REPL interpreter from printing the value of 
+    Context manager to prevent the REPL interpreter from printing the value of
     any expressions within the for loop that don't evaluate to None.
 
-    Printing is relatively expensive, and so this behavior can easily lead to 
+    Printing is relatively expensive, and so this behavior can easily lead to
     timings that are much longer than they should be.
     """
     def __enter__(self):
@@ -907,8 +903,6 @@ class _SetDisplayHook(object):
 
     def __exit__(self, ex_type, ex_value, trace):
         sys.displayhook = self._orig_display_hook
-
-
 
 
 def _chunks(seq, size):


### PR DESCRIPTION
This PR changes the default behavior of the loop from running a single iteration to running as many iterations as possible in 200 ms, similar to the behavior of the `timeit` command-line program.  I find this a lot more convenient, since I often don't know a priori how long each iteration will take.