### PR TITLE
Allow default verbosity to be configured via environment variable

### DIFF
--- a/timerit/core.py
+++ b/timerit/core.py
@@ -49,6 +49,7 @@ Example:
 """
 import time
 import sys
+import os
 import itertools as it
 from collections import defaultdict, OrderedDict
 
@@ -302,8 +303,10 @@ class Timerit:
 
             verbose (int | None):
                 Verbosity level. Higher is more verbose, distinct text is
-                written at levels 1, 2, and 3. If unspecified, defaults to 1 if
-                label is given and 0 otherwise.
+                written at levels 1, 2, and 3. If unspecified, the
+                ``$TIMERIT_VERBOSE`` environment is checked for a value.  If
+                still unspecified, defaults to 1 if label is given and 0
+                otherwise.
 
             disable_gc (bool):
                 If True, disables the garbage collector while timing, defaults to
@@ -314,7 +317,10 @@ class Timerit:
                 customized one. Mainly useful for testing.
         """
         if verbose is None:
+            verbose = os.environ.get('TIMERIT_VERBOSE')
+        if verbose is None:
             verbose = bool(label)
+        verbose = int(verbose)
 
         self.num = num
         self.label = label
@@ -807,9 +813,9 @@ class Timerit:
         Example:
             >>> import math
             >>> from timerit import Timer
-            >>> Timerit(num=10).call(math.factorial, 50).print(verbose=1)
-            >>> Timerit(num=10).call(math.factorial, 50).print(verbose=2)
-            >>> Timerit(num=10).call(math.factorial, 50).print(verbose=3)
+            >>> Timerit(num=10, verbose=0).call(math.factorial, 50).print(verbose=1)
+            >>> Timerit(num=10, verbose=0).call(math.factorial, 50).print(verbose=2)
+            >>> Timerit(num=10, verbose=0).call(math.factorial, 50).print(verbose=3)
             Timed best=...s, mean=...s
             Timed for: 10 loops, best of 3
                 time per loop: best=...s, mean=...s


### PR DESCRIPTION
This PR adds an environment variable, `$TIMERIT_VERBOSE`, that controls the default verbosity level of `Timerit` instances.  My goal was to provide a way to make `verbose=2` into the default, since that's usually the amount of information that I want to see when I'm experimenting with snippets of code like this, and it's annoying to have to specify `verbose=2` over and over when experimenting in the REPL.  An environment variable is probably the most flexible way to do this, but I also think it might be appropriate to just change the default to 2, since that's the value that's used for most of the examples in the documentation already.